### PR TITLE
Change level3 altr to altwin

### DIFF
--- a/ir
+++ b/ir
@@ -20,7 +20,7 @@ xkb_symbols "pes" {
     include "ir(pes_part_ext)"
 
     include "nbsp(zwnj2nb3nnb4)"
-    include "level3(ralt_switch)"
+    include "altwin(menu)"
 };
 
 partial alphanumeric_keys
@@ -31,7 +31,7 @@ xkb_symbols "pes_win" {
     include "ir(pes_part_ext_win)"
 
     include "nbsp(zwnj2nb3nnb4)"
-    include "level3(ralt_switch)"
+    include "altwin(menu)"
 };
 
 
@@ -45,7 +45,7 @@ xkb_symbols "pes_keypad" {
     include "ir(pes_part_keypad)"
 
     include "nbsp(zwnj2nb3nnb4)"
-    include "level3(ralt_switch)"
+    include "altwin(menu)"
 };
 
 hidden partial alphanumeric_keys
@@ -321,7 +321,7 @@ xkb_symbols "ku_ara" {
     key <AB10> { [ slash,		Arabic_question_mark, 	question	] };
 
     include "nbsp(zwnj2nb3)"
-    include "level3(ralt_switch)"
+    include "altwin(menu)"
 };
 
 // EXTRAS:


### PR DESCRIPTION
I did this a long time ago and I'm not using ubuntu anymore but this commit basically changed all occurrences of level3(ralt_switch) to altwin(menu) so that keyboard shortcuts like alt+shift could work natively.

Not sure if it's still helpful or it's the right way to do it, but might as well create this pull request. Thanks for making this great project!